### PR TITLE
added links related to the project for reference

### DIFF
--- a/CodeManifesto/ProjectCodeStructure.md
+++ b/CodeManifesto/ProjectCodeStructure.md
@@ -1,4 +1,4 @@
-# Project Structure
+# Project Code Structure
 
 This chapter will discuss about the file structure of this project and how the project should be organized.
 Because of how game development works, this chapter will change depending on what type of assets we add to the game.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This is the project manual for **Catch.io** and a repository for tracking issues and tasks related to the development of Catch.io.
-The actual source code for the project will be managed in a separate private repository, while the project progress and other instructions are stored in here.
+The actual source code for the project will be managed in a separate private repository while the instructions, standards and other project development-related documentations will be stored in here.
 If you are part of development team, feel free to add new tasks or comment on existing ones.
 
 Every information that is required for developing with the Project Catch.io team will be documented here.
@@ -19,16 +19,29 @@ Such information includes:
 
 and more...
 
-You can think of this as a general guidelines for how to unify the development process so it is easier for others to join in. So project team members should document their work and tell everyone how you want others to handle your work. Project docs are meant for internal use but you shouldn't assume that others might already know what is what. Think of the docs as a way to express your creative works.
+You can think of this as a general guideline and a starting point for joining the team or unifying how our works should be prevented in order for them to be considered 'finished'.
+To keep things organized, project members should document their work and tell everyone how you want others to handle your work.
 Please keep in mind that you are not expected to read all the docs, but you are expected to understand the parts that is related to your task.
 
-Regarding the development flow, please refer to this doc: [Github Guide](OrganizationManuals/GithubGuide.md)
+## Project Resources
 
-If you are an artist, this document may help you: [Art Asset Structure](ArtAssetStructure.md)
+All resources and documents related to the development of project Catch.io is split amongst various repositories, sites and services.
+We will list all of them here and explain what their purposes are.
+Some of the links listed here will not be accessible by the public while some are.
+Please change the list content if we decide to make adjustments to the team management structure.
 
-For the design documents of Project Catch.io, please refer to this doc: <https://team-step.gitbook.io/catch-io-design-doc/>
+- Catch.io Project Repository: The repository for the source code of project Catch.io. This repository is made private, and we only allow access to project developers. However, contents like code documentation or on-going test builds will be made available to the public with the power of Github CI.
+- [Catch.io docs repository](https://github.com/TeamSTEP/catch.io-docs): The source code for project developer references are kept in this repository. Currently, this repo contains two different document pages.
+  - [Gitbook Dev Doc](https://team-step.gitbook.io/catch-io-dev-doc/): The developer reference page hosted on Gitbook in Markdown pages. Page contents are manually updated, and this page contains the description for each script, Unity scene and prefabs used in the project. Due to the difficulty of maintaining an updated reference doc, this page is currently suspended. The contents are automatically synced with the source repo.
+  - [Project Scripting API page](https://teamstep.github.io/catch.io-docs/index.html): Hosted via Github Pages, this page contains the auto generated scripting reference for this project. The content of this page will change with every updates made to the Catch.io source code. It is convenient, but hard to migrate to other pages as this does not use Markdown for API references (only code manuals are in Markdown).
+- [Google Drive Shared Folder](https://drive.google.com/drive/folders/172WUcDN0RhsPbsiyHHZ8ynre-7dhNVDn?usp=sharing): Internal documents, weekly meeting records, brainstorming records, project expenses, art/music assets for the project and other information that are meant to be stored for a long time and only meant for team members will be stored here. Non-programmers will mostly interact with Google Drive.
+- [Itch.io page](https://hoonkim.itch.io/catch-io): Itch.oi is used for sharing quick prototype builds of the game (in WebGL for most cases) both inside and outside of the team. Generally, this page is used for quick internal testing, but we may consider releasing the game here at some point.
+- [Trello Project Board](https://trello.com/b/0IsVDWOC/catchio-project-log): Still experimental, but this is where the development progress regarding Catch.io will be tracked.
+- [Catch.io GDD](https://team-step.gitbook.io/catch-io-design-doc/): Hosted by Gitbook, this page contains everything about the project such as the game mechanics, expected features, rough timeline, expected release platforms, general marketing strategy, pivot strategies, and more.
 
-This README doc acts as an introduction to the entire docs so please feel free to add or change the contents as you write more docs.
+If you are a developer for Catch.io, please refer to this doc: [Github Guide](OrganizationManuals/GithubGuide.md) and [this doc](CodeManifesto/ProjectCodeStructure.md) as a starting point for our coding guidelines.
+
+If you are an artist, please start from here: [Art Asset Structure](ArtAssetStructure.md).
 
 ## Abbreviations & Definitions
 


### PR DESCRIPTION
This will add all the links for the pages and services that our team members are using for project catch.io. Of course, private services will require special access.